### PR TITLE
add responses tools example

### DIFF
--- a/examples/responses-tools/main.go
+++ b/examples/responses-tools/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared"
+)
+
+func main() {
+	client := openai.NewClient()
+	ctx := context.Background()
+
+	question := "Find the world's tallest mountain and double its height using code"
+
+	resp, err := client.Responses.New(ctx, responses.ResponseNewParams{
+		Model: shared.ResponsesModel("gpt-4o-mini"),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String(question),
+		},
+		Tools: []responses.ToolUnionParam{
+			responses.ToolParamOfWebSearchPreview(responses.WebSearchToolTypeWebSearchPreview),
+			responses.ToolParamOfCodeInterpreter(responses.ToolCodeInterpreterContainerCodeInterpreterContainerAutoParam{}),
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(resp.OutputText())
+}

--- a/responses/response_tools_test.go
+++ b/responses/response_tools_test.go
@@ -1,0 +1,52 @@
+package responses_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/internal/testutil"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared"
+)
+
+func TestResponseWithBrowserAndCodeInterpreter(t *testing.T) {
+	baseURL := "http://localhost:4010"
+	if envURL, ok := os.LookupEnv("TEST_API_BASE_URL"); ok {
+		baseURL = envURL
+	}
+	if !testutil.CheckTestServer(t, baseURL) {
+		return
+	}
+	client := openai.NewClient(
+		option.WithBaseURL(baseURL),
+		option.WithAPIKey("My API Key"),
+	)
+	_, err := client.Responses.New(context.TODO(), responses.ResponseNewParams{
+		Model: shared.ResponsesModel("gpt-4o"),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfString: openai.String("Search for a mountain and compute a value"),
+		},
+		Prompt: responses.ResponsePromptParam{
+			ID:      "id",
+			Version: openai.String("v1"),
+			Variables: map[string]responses.ResponsePromptVariableUnionParam{
+				"topic": {OfString: openai.String("mountain")},
+			},
+		},
+		Tools: []responses.ToolUnionParam{
+			responses.ToolParamOfWebSearchPreview(responses.WebSearchToolTypeWebSearchPreview),
+			responses.ToolParamOfCodeInterpreter(responses.ToolCodeInterpreterContainerCodeInterpreterContainerAutoParam{}),
+		},
+	})
+	if err != nil {
+		var apierr *openai.Error
+		if errors.As(err, &apierr) {
+			t.Log(string(apierr.DumpRequest(true)))
+		}
+		t.Fatalf("err should be nil: %s", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- add example using Browser and Code Interpreter tools with the Responses API
- add test exercising Response requests with browser and code interpreter tools

## Testing
- `go test ./...` *(fails: dial tcp [::1]:4010: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6892f8f88ad083218d3e9480bdffea55